### PR TITLE
Differentiate between empty and unset values.

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -7,10 +7,10 @@ package envconfig
 import (
 	"errors"
 	"fmt"
-	"os"
 	"reflect"
 	"strconv"
 	"strings"
+	"syscall"
 )
 
 // ErrInvalidSpecification indicates that a specification is of the wrong type.
@@ -44,14 +44,17 @@ func Process(prefix string, spec interface{}) error {
 				fieldName = alt
 			}
 			key := strings.ToUpper(fmt.Sprintf("%s_%s", prefix, fieldName))
-			value := os.Getenv(key)
-			if value == "" && alt != "" {
+			// `os.Getenv` cannot differentiate between an explicitly set empty value
+			// and an unset value. `os.LookupEnv` is preferred to `syscall.Getenv`,
+			// but it is only available in go1.5 or newer.
+			value, ok := syscall.Getenv(key)
+			if !ok && alt != "" {
 				key := strings.ToUpper(fieldName)
-				value = os.Getenv(key)
+				value, ok = syscall.Getenv(key)
 			}
 
 			def := typeOfSpec.Field(i).Tag.Get("default")
-			if def != "" && value == "" {
+			if def != "" && !ok {
 				value = def
 			}
 

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -204,6 +204,21 @@ func TestNonBlankDefaultVar(t *testing.T) {
 	}
 }
 
+func TestExplicitBlankDefaultVar(t *testing.T) {
+	var s Specification
+	os.Clearenv()
+	os.Setenv("ENV_CONFIG_DEFAULTVAR", "")
+	os.Setenv("ENV_CONFIG_REQUIREDVAR", "requiredvalue")
+
+	if err := Process("env_config", &s); err != nil {
+		t.Error(err.Error())
+	}
+
+	if s.DefaultVar != "" {
+		t.Errorf("expected %s, got %s", "\"\"", s.DefaultVar)
+	}
+}
+
 func TestAlternateNameDefaultVar(t *testing.T) {
 	var s Specification
 	os.Clearenv()


### PR DESCRIPTION
The previous implementation used `os.Getenv`, which does not differentiate
between an empty and an unset environment variable -- both return the empty
string with `os.Getenv`.

The new implementation uses `syscall.Getenv`, which is what `os.Getenv` uses
directly under the hood. go1.5 introduced `os.LookupEnv` to solve this exact
problem, but it has not been backported.
